### PR TITLE
fix unescaped quote in data.sql

### DIFF
--- a/scripts/k8s/sql/data.sql
+++ b/scripts/k8s/sql/data.sql
@@ -14,4 +14,4 @@ INSERT INTO `baetyl_property` (`name`, `value`) VALUES
 ('command-k3s-installation-containerd', 'curl -sfL http://rancher-mirror.cnrancher.com/k3s/k3s-install.sh | INSTALL_K3S_MIRROR=cn INSTALL_K3S_EXEC="--write-kubeconfig ~/.kube/config --write-kubeconfig-mode 666" sh -'),
 ('command-k3s-installation-docker', 'curl -sfL http://rancher-mirror.cnrancher.com/k3s/k3s-install.sh | INSTALL_K3S_MIRROR=cn INSTALL_K3S_EXEC="--docker --write-kubeconfig ~/.kube/config --write-kubeconfig-mode 666" sh -'),
 
-('baetyl-kube-init-command', 'curl -skfL '{{GetProperty "init-server-address"}}/v1/init/{{.InitApplyYaml}}?token={{.Token}}' -oinit.yml && kubectl delete clusterrolebinding baetyl-edge-system-rbac --ignore-not-found=true && kubectl delete ns baetyl-edge-system --ignore-not-found=true && kubectl apply -f init.yml');
+('baetyl-kube-init-command', 'curl -skfL \'{{GetProperty "init-server-address"}}/v1/init/{{.InitApplyYaml}}?token={{.Token}}\' -oinit.yml && kubectl delete clusterrolebinding baetyl-edge-system-rbac --ignore-not-found=true && kubectl delete ns baetyl-edge-system --ignore-not-found=true && kubectl apply -f init.yml');

--- a/scripts/native/sql/data.sql
+++ b/scripts/native/sql/data.sql
@@ -14,4 +14,4 @@ INSERT INTO `baetyl_property` (`name`, `value`) VALUES
 ('command-k3s-installation-containerd', 'curl -sfL http://rancher-mirror.cnrancher.com/k3s/k3s-install.sh | INSTALL_K3S_MIRROR=cn INSTALL_K3S_EXEC="--write-kubeconfig ~/.kube/config --write-kubeconfig-mode 666" sh -'),
 ('command-k3s-installation-docker', 'curl -sfL http://rancher-mirror.cnrancher.com/k3s/k3s-install.sh | INSTALL_K3S_MIRROR=cn INSTALL_K3S_EXEC="--docker --write-kubeconfig ~/.kube/config --write-kubeconfig-mode 666" sh -'),
 
-('baetyl-kube-init-command', 'curl -skfL '{{GetProperty "init-server-address"}}/v1/init/{{.InitApplyYaml}}?token={{.Token}}' -oinit.yml && kubectl delete clusterrolebinding baetyl-edge-system-rbac --ignore-not-found=true && kubectl delete ns baetyl-edge-system --ignore-not-found=true && kubectl apply -f init.yml');
+('baetyl-kube-init-command', 'curl -skfL \'{{GetProperty "init-server-address"}}/v1/init/{{.InitApplyYaml}}?token={{.Token}}\' -oinit.yml && kubectl delete clusterrolebinding baetyl-edge-system-rbac --ignore-not-found=true && kubectl delete ns baetyl-edge-system --ignore-not-found=true && kubectl apply -f init.yml');


### PR DESCRIPTION
unescaped quote mark in data.sql cause phpmyadmin errored with `SQL syntax error`. this PR may fix that.


and, BTW, [the installation guide](https://baetyl.readthedocs.io/en/latest/develop/install.html) has some inconsistence in terms of my actual deploying procedure:
 - the env `POD_NAME` exported in section [initialize data](https://baetyl.readthedocs.io/en/latest/develop/install.html#initialize-data) with `export POD_NAME=$(kubectl get pods --namespace default -l "app=phpmyadmin,release=phpmyadmin" -o jsonpath="{.items[0].metadata.name}")` not works. conversely, selector `-l "app.kubernetes.io/instance=phpmyadmin"` works on my machine.
 - in section [install database](https://baetyl.readthedocs.io/en/latest/develop/install.html#install-database), default rootpassword and dbname provided are not set for mariadb, mariadb still initialize itself with a random rootpassword and database name `my_database`. you should use `--set auth.rootPassword=secretpassword,auth.database=baetyl_cloud` according to [its document](https://github.com/bitnami/charts/tree/master/bitnami/mariadb/#installing-the-chart) thus the entries you provided is obsolete.