### PR TITLE
simplify cross build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 MODULE:=baetyl-cloud
 SRC_FILES:=$(shell find . -type f -name '*.go')
-PLATFORM_ALL:=darwin/amd64 linux/amd64 linux/arm64 linux/arm/v7
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
@@ -8,39 +7,32 @@ GIT_TAG:=$(shell git tag --contains HEAD|awk 'END {print}')
 GIT_REV:=git-$(shell git rev-parse --short HEAD)
 VERSION:=$(if $(GIT_TAG),$(GIT_TAG),$(GIT_REV))
 
-GO_FLAGS:=-ldflags '-s -w -X "github.com/baetyl/baetyl-go/v2/utils.REVISION=$(GIT_REV)" -X "github.com/baetyl/baetyl-go/v2/utils.VERSION=$(VERSION)"'
+GO_FLAGS:=-s -w -X github.com/baetyl/baetyl-go/v2/utils.REVISION=$(GIT_REV) -X github.com/baetyl/baetyl-go/v2/utils.VERSION=$(VERSION)
+GO_PROXY:=$(shell go env GOPROXY)
 GO_TEST_FLAGS:=-race -short -covermode=atomic -coverprofile=coverage.txt
 GO_TEST_PKGS:=$(shell go list ./...)
-ifndef PLATFORMS
-	GO_OS:=$(shell go env GOOS)
-	GO_ARCH:=$(shell go env GOARCH)
-	GO_ARM:=$(shell go env GOARM)
-	PLATFORMS:=$(if $(GO_ARM),$(GO_OS)/$(GO_ARCH)/$(GO_ARM),$(GO_OS)/$(GO_ARCH))
-	ifeq ($(GO_OS),darwin)
-		PLATFORMS+=linux/amd64
-	endif
-else ifeq ($(PLATFORMS),all)
-	override PLATFORMS:=$(PLATFORM_ALL)
-endif
 
-REGISTRY:=
-XFLAGS:=--load
-XPLATFORMS:=$(shell echo $(filter-out darwin/amd64,$(PLATFORMS)) | sed 's: :,:g')
+REGISTRY?=
 
 .PHONY: all
 all: build
 
 .PHONY: build
 build: $(SRC_FILES)
-	env GO111MODULE=on GOPROXY=https://goproxy.cn CGO_ENABLED=0 go build -o output/$(MODULE) $(GO_FLAGS) .
+	env CGO_ENABLED=0 go build -o output/$(MODULE) -ldflags "$(GO_FLAGS)" .
 
 .PHONY: image
 image:
 	@echo "BUILDX: $(REGISTRY)$(MODULE):$(VERSION)"
 	@-docker buildx create --name $(MODULE)
 	@docker buildx use $(MODULE)
-	@docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-	docker buildx build $(XFLAGS) --platform $(XPLATFORMS) -t $(REGISTRY)$(MODULE):$(VERSION) -f Dockerfile .
+	docker buildx build --push \
+		--platform linux/amd64,linux/arm64,linux/arm/v7 \
+		-t $(REGISTRY)$(MODULE):$(VERSION) \
+		--build-arg GOPROXY="$(GO_PROXY)" \
+		--build-arg GIT_REV="$(GIT_REV)" \
+		--build-arg VERSION="$(VERSION)" \
+		-f Dockerfile .
 
 .PHONY: test
 test: fmt


### PR DESCRIPTION
Use golang:alpine as builder image instead of golang:stretch to shrink image downloading
Use linux/amd64 as build environment instead of qemu-user since golang itself already have cross build ability
Use scratch as base instead of busybox to even shrink image size
Build linux/amd64, linux/arm64, linux/arm/v7 only, maybe just first 2 is enough
Replace hard coded GOPROXY into `go env GOPROXY`
Read ${REGISTRY} from env

# Usage
env REGISTRY=baetyl/ make image